### PR TITLE
Fix bug with non-standard MQTT configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,23 @@
+---
+categories:
+  - title: "🚨 Breaking Changes"
+    labels:
+      - "breaking change"
+  - title: "🚀 Features"
+    labels:
+      - "enhancement"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "bug"
+  - title: "🧰 Maintenance"
+    labels:
+      - "ci/cd"
+      - "dependencies"
+      - "documentation"
+      - "maintenance"
+      - "tooling"
+change-template: "- $TITLE (#$NUMBER)"
+name-template: "$NEXT_PATCH_VERSION"
+tag-template: "$NEXT_PATCH_VERSION"
+template: |
+  $CHANGES

--- a/ecowitt2mqtt/config.yaml
+++ b/ecowitt2mqtt/config.yaml
@@ -9,8 +9,6 @@ description: >-
   A small web server to send data from Ecowitt devices to an MQTT Broker
 image: "ghcr.io/bachya/home-assistant-addon-ecowitt2mqtt"
 init: false
-map:
-  - share:rw
 name: home-assistant-addon-ecowitt2mqtt
 options:
   default_battery_strategy: numeric

--- a/ecowitt2mqtt/run.sh
+++ b/ecowitt2mqtt/run.sh
@@ -8,12 +8,12 @@ bashio::log.info "Fetching configuration..."
 MQTT_HOST=""
 MQTT_PASSWORD=""
 MQTT_PORT=1883
-MQTT_UERSNAME=""
+MQTT_USERNAME=""
 
 if bashio::services.available "mqtt"; then
   MQTT_HOST="$(bashio::services "mqtt" "host")"
   MQTT_PORT="$(bashio::services "mqtt" "port")"
-  MQTT_UERSNAME="$(bashio::services "mqtt" "username")"
+  MQTT_USERNAME="$(bashio::services "mqtt" "username")"
   MQTT_PASSWORD="$(bashio::services "mqtt" "password")"
 fi
 
@@ -24,15 +24,15 @@ fi
 if bashio::config.has_value 'mqtt_port'; then
   MQTT_PORT="$(bashio::config 'mqtt_port')"
 fi
-if bashio::config.has_value 'mqtt_user'; then
-  MQTT_UERSNAME="$(bashio::config 'mqtt_user')"
+if bashio::config.has_value 'mqtt_username'; then
+  MQTT_USERNAME="$(bashio::config 'mqtt_username')"
 fi
-if bashio::config.has_value 'mqtt_pass'; then
-  MQTT_PASSWORD="$(bashio::config 'mqtt_pass')"
+if bashio::config.has_value 'mqtt_password'; then
+  MQTT_PASSWORD="$(bashio::config 'mqtt_password')"
 fi
 
 # Fail if we're missing MQTT config:
-if [[ -z "${MQTT_HOST}" || -z "${MQTT_PORT}" || -z "${MQTT_UERSNAME}" || -z "${MQTT_PASSWORD}" ]]; then
+if [[ -z "${MQTT_HOST}" || -z "${MQTT_PORT}" || -z "${MQTT_USERNAME}" || -z "${MQTT_PASSWORD}" ]]; then
   bashio::log.fatal "MQTT configuration not found; cannot continue."
   exit 1
 fi
@@ -40,7 +40,7 @@ fi
 # Log the MQTT parameters:
 bashio::log.info "Using MQTT host: ${MQTT_HOST}"
 bashio::log.info "Using MQTT port: ${MQTT_PORT}"
-bashio::log.info "Using MQTT username: ${MQTT_UERSNAME}"
+bashio::log.info "Using MQTT username: ${MQTT_USERNAME}"
 bashio::log.info "Using MQTT password: REDACTED"
 
 # Define config options to use:
@@ -79,7 +79,7 @@ bashio::log.info "Starting Ecowitt2MQTT"
 ecowitt2mqtt \
     --mqtt-broker="${MQTT_HOST}" \
     --mqtt-port="${MQTT_PORT}" \
-    --mqtt-username="${MQTT_UERSNAME}" \
+    --mqtt-username="${MQTT_USERNAME}" \
     --mqtt-password="${MQTT_PASSWORD}" \
     --port=8080 \
     --hass-discovery \


### PR DESCRIPTION
**Describe what the PR does:**

The `ecowitt2mqtt` add-on would fail to start if using a separate MQTT broker (i.e., anything other than the Mosquitto add-on). This PR fixes the bug.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Update `README.md` with any new documentation.
