### PR TITLE
Bump ecowitt2mqtt to 2022.07.5

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,3 +7,4 @@ Fixes https://github.com/bachya/home-assistant-addons/issues/<ISSUE ID>
 **Checklist:**
 
 - [ ] Update `README.md` with any new documentation.
+- [ ] Update `CHANGELOG.md` with any new documentation.

--- a/ecowitt2mqtt/CHANGELOG.md
+++ b/ecowitt2mqtt/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 2022.07.5
+
+## `ecowitt2mqtt`
+
+https://github.com/bachya/ecowitt2mqtt/releases/tag/2022.07.5
+
+## Add-on
+
+* Bump `ecowitt2mqtt` to 2022.07.5
+* Fix bug with non-standard MQTT configuration (#7)
+* Reorganize the repo to handle future other add-ons (#6)
+
 # 2022.07.4
 
 ## `ecowitt2mqtt`
@@ -6,4 +18,4 @@ https://github.com/bachya/ecowitt2mqtt/releases/tag/2022.07.4
 
 ## Add-on
 
-* Initial release of the addon
+* Create v1 of the add-on (#4)

--- a/ecowitt2mqtt/Dockerfile
+++ b/ecowitt2mqtt/Dockerfile
@@ -2,7 +2,7 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
 
-ARG ECOWITT2MQTT_VERSION=2022.07.4
+ARG ECOWITT2MQTT_VERSION=2022.07.5
 
 # Install and build ecowitt2mqtt:
 RUN apk add --no-cache \

--- a/ecowitt2mqtt/config.yaml
+++ b/ecowitt2mqtt/config.yaml
@@ -42,4 +42,4 @@ services:
   - "mqtt:want"
 slug: ecowitt2mqtt
 url: "https://github.com/bachya/home-assistant-addons/tree/dev/ecowitt2mqtt"
-version: "2022.07.4"
+version: "2022.07.5"


### PR DESCRIPTION
**Describe what the PR does:**

This PR bumps the `ecowitt2mqtt` add-on to 2022.07.5.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [x] Update `CHANGELOG.md` with any new documentation.
