### PR TITLE
Bump `ecowitt2mqtt` to 2022.08.0

### DIFF
--- a/ecowitt2mqtt/CHANGELOG.md
+++ b/ecowitt2mqtt/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2022.08.0
+
+## `ecowitt2mqtt`
+
+https://github.com/bachya/ecowitt2mqtt/releases/tag/2022.08.0
+
+## Add-on
+
+* Bump `ecowitt2mqtt` to 2022.08.0 (#13)
+
 # 2022.07.7
 
 ## `ecowitt2mqtt`

--- a/ecowitt2mqtt/Dockerfile
+++ b/ecowitt2mqtt/Dockerfile
@@ -2,7 +2,7 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
 
-ARG ECOWITT2MQTT_VERSION=2022.07.7
+ARG ECOWITT2MQTT_VERSION=2022.08.0
 
 # Install and build ecowitt2mqtt:
 RUN apk add --no-cache \

--- a/ecowitt2mqtt/config.yaml
+++ b/ecowitt2mqtt/config.yaml
@@ -44,4 +44,4 @@ services:
   - "mqtt:want"
 slug: ecowitt2mqtt
 url: "https://github.com/bachya/home-assistant-addons/tree/dev/ecowitt2mqtt"
-version: "2022.07.7"
+version: "2022.08.0"


### PR DESCRIPTION
**Describe what the PR does:**

This PR bumps `ecowitt2mqtt` to 2022.08.0.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Update `CHANGELOG.md` with any new documentation.
