### PR TITLE
Bump `ecowitt2mqtt` to 2022.08.5

### DIFF
--- a/ecowitt2mqtt/CHANGELOG.md
+++ b/ecowitt2mqtt/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2022.08.5
+
+## `ecowitt2mqtt`
+
+https://github.com/bachya/ecowitt2mqtt/releases/tag/2022.08.5
+
+## Add-on
+
+* Bump `ecowitt2mqtt` to 2022.08.5 (#24)
+
 # 2022.08.4
 
 ## `ecowitt2mqtt`

--- a/ecowitt2mqtt/CHANGELOG.md
+++ b/ecowitt2mqtt/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 https://github.com/bachya/ecowitt2mqtt/releases/tag/2022.08.5
 
+Note that 2022.08.5 introduces the ability to specify multiple independent gateway
+configurations via the config file. Using the config file is not supported via this
+add-on. This shouldn't be necessary, as Home Assistant MQTT Discovery handles nearly
+all of these use cases.
+
 ## Add-on
 
 * Bump `ecowitt2mqtt` to 2022.08.5 (#24)

--- a/ecowitt2mqtt/CHANGELOG.md
+++ b/ecowitt2mqtt/CHANGELOG.md
@@ -5,9 +5,9 @@
 https://github.com/bachya/ecowitt2mqtt/releases/tag/2022.08.5
 
 Note that 2022.08.5 introduces the ability to specify multiple independent gateway
-configurations via the config file. Using the config file is not supported via this
-add-on. This shouldn't be necessary, as Home Assistant MQTT Discovery handles nearly
-all of these use cases.
+configurations via the config file, but Home Assistant users should noet that the config
+file is not supported in this add-on. Home Assistant MQTT Discovery handles multiple
+Ecowitt gateways natively.
 
 ## Add-on
 

--- a/ecowitt2mqtt/Dockerfile
+++ b/ecowitt2mqtt/Dockerfile
@@ -2,7 +2,7 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
 
-ARG ECOWITT2MQTT_VERSION=2022.08.4
+ARG ECOWITT2MQTT_VERSION=2022.08.5
 
 # Install and build ecowitt2mqtt:
 RUN apk add --no-cache \

--- a/ecowitt2mqtt/config.yaml
+++ b/ecowitt2mqtt/config.yaml
@@ -44,4 +44,4 @@ services:
   - "mqtt:want"
 slug: ecowitt2mqtt
 url: "https://github.com/bachya/home-assistant-addons/tree/main/ecowitt2mqtt"
-version: "2022.08.4"
+version: "2022.08.5"


### PR DESCRIPTION
**Describe what the PR does:**

This PR bumps `ecowitt2mqtt` to 2022.08.5.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Update `CHANGELOG.md` with any new documentation.
