### PR TITLE
Bump `ecowitt2mqtt` to 2022.09.1

### DIFF
--- a/ecowitt2mqtt/CHANGELOG.md
+++ b/ecowitt2mqtt/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Add-on
 
-* Bump `ecowitt2mqtt` to 2022.09.1 (#26)
+* Bump `ecowitt2mqtt` to 2022.09.1 (#27)
 
 # 2022.09.0
 

--- a/ecowitt2mqtt/CHANGELOG.md
+++ b/ecowitt2mqtt/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2022.09.1
+
+## `ecowitt2mqtt`
+
+* https://github.com/bachya/ecowitt2mqtt/releases/tag/2022.09.1
+
+## Add-on
+
+* Bump `ecowitt2mqtt` to 2022.09.1 (#26)
+
 # 2022.09.0
 
 ## `ecowitt2mqtt`

--- a/ecowitt2mqtt/Dockerfile
+++ b/ecowitt2mqtt/Dockerfile
@@ -2,7 +2,7 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
 
-ARG ECOWITT2MQTT_VERSION=2022.09.0
+ARG ECOWITT2MQTT_VERSION=2022.09.1
 
 # Install and build ecowitt2mqtt:
 RUN apk add --no-cache \

--- a/ecowitt2mqtt/config.yaml
+++ b/ecowitt2mqtt/config.yaml
@@ -44,4 +44,4 @@ services:
   - "mqtt:want"
 slug: ecowitt2mqtt
 url: "https://github.com/bachya/home-assistant-addons/tree/main/ecowitt2mqtt"
-version: "2022.09.0"
+version: "2022.09.1"


### PR DESCRIPTION
**Describe what the PR does:**

This PR bumps `ecowitt2mqtt` to 2022.09.1.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Update `CHANGELOG.md` with any new documentation.
