### PR TITLE
Attempt to download wheels from piwheels.org during ARMv6/ARMv7 build

### DIFF
--- a/ecowitt2mqtt/CHANGELOG.md
+++ b/ecowitt2mqtt/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Add-on
 
+- Attempt to download wheels from piwheels.org during ARMv6/ARMv7 build (#104)
 - Remove i386 as a target (#103)
 - Bump `ecowitt2mqtt` to 2023.08.0 (#102)
 - Bump blacken-docs from 1.15.0 to 1.16.0 (#101)

--- a/ecowitt2mqtt/CHANGELOG.md
+++ b/ecowitt2mqtt/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Add-on
 
-- Attempt to download wheels from piwheels.org during ARMv6/ARMv7 build (#104)
+- Attempt to download wheels from piwheels.org during ARMv6/ARMv7 build (#105)
 - Remove i386 as a target (#103)
 - Bump `ecowitt2mqtt` to 2023.08.0 (#102)
 - Bump blacken-docs from 1.15.0 to 1.16.0 (#101)

--- a/ecowitt2mqtt/Dockerfile
+++ b/ecowitt2mqtt/Dockerfile
@@ -16,6 +16,7 @@ RUN apk add --no-cache \
         libc-dev \
         musl-dev \
     && python3 -m ensurepip \
+    && printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf \
     && pip3 install --no-cache-dir --upgrade pip setuptools wheel \
     && pip3 install --no-cache-dir ecowitt2mqtt==${ECOWITT2MQTT_VERSION} \
     && apk del build-dependencies


### PR DESCRIPTION
**Describe what the PR does:**

We do this so those architectures don't fail without a Rust runtime.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/home-assistant-addons/issues/104

**Checklist:**

- [ ] Update `README.md` with any new documentation.
- [ ] Update `CHANGELOG.md` with any new documentation.
